### PR TITLE
refactor: reduce backend image from 15GB to under 2GB

### DIFF
--- a/demo/backend/Dockerfile
+++ b/demo/backend/Dockerfile
@@ -1,25 +1,25 @@
 # syntax=docker/dockerfile:1
-# Use an official TensorFlow runtime as a parent image
-FROM tensorflow/tensorflow:2.16.2-gpu AS hwcalc-backend-builder
+# Stage 1
+# Use a Slim release as a parent image, installing dependencies
+FROM python:3.11-slim-buster AS hwcalc-backend-builder
 WORKDIR /app
+COPY requirements.txt requirements.txt
+RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
+
+# Stage 2 - copy only necessary files
+FROM python:3.11-slim-buster AS hwcalc-backend-svc
+WORKDIR /app
+
+COPY --from=hwcalc-backend-builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY . .
+
 ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0
 ENV FLASK_RUN_PORT=5001
-
-# the TensorFlow image is based on Ubuntu, so we can use apt-get
-# Update and install some libraries
-RUN apt-get update && apt install ffmpeg libsm6 libxext6 -y
-
-COPY requirements.txt requirements.txt
-# Install any needed packages specified in requirements.txt
-# RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
-
-# blinker is already installed by distutils, we will ignore it
-RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt --ignore-installed
-
-EXPOSE 5001
-COPY . .
 ENV DATA_PATH=./
 ENV MODEL_PATH=./trained_models
 ENV MODEL_TYPE=mlp
-CMD ["flask", "run", "--debug"]
+
+EXPOSE 5001
+
+CMD ["python", "-m", "flask", "run"]

--- a/demo/backend/README.md
+++ b/demo/backend/README.md
@@ -21,6 +21,8 @@ source development.env
 flask run
 ```
 
+**Note** The 'capture' functionality of the service will only function properly (writing input images to local disk) when it is run manually, as in this usage.
+
 ### Test Service Heartbeat Endpoint
 
 Use [http://localhost:5001/heartbeat](http://localhost:5001/heartbeat) to check backend health.

--- a/demo/backend/requirements.txt
+++ b/demo/backend/requirements.txt
@@ -1,5 +1,4 @@
 flask==3.1.0
-matplotlib==3.10.1
 numpy==1.26.4
 pillow==11.2.1
-tensorflow==2.16.2
+tensorflow-cpu==2.16.2

--- a/demo/compose.yaml
+++ b/demo/compose.yaml
@@ -2,7 +2,7 @@ services:
   hwcalc-backend:
     build:
       context: ./backend
-      target: hwcalc-backend-builder
+      target: hwcalc-backend-svc
     environment:
       - MODEL_TYPE=cnn
     # flask requires SIGINT to stop gracefully


### PR DESCRIPTION
Brought backend image size down from 15GB (tensorflow) down to under 2GB (Slim-buster + tensorflow-cpu). For the model evaluation GPU is not needed. Also tightened up the Docker build, now two stages.